### PR TITLE
Make Laravel5.2-compatible

### DIFF
--- a/ServiceProvider.php
+++ b/ServiceProvider.php
@@ -30,7 +30,7 @@ class ServiceProvider extends Provider
      */
     protected function registerDateIntlBuilder()
     {
-        $this->app->bindShared('dateintl', function ($app) {
+        $this->app->singleton('dateintl', function ($app) {
             return new DateIntlBuilder();
         });
     }


### PR DESCRIPTION
The bindShared method is removed in L5.2 (deprecated in L5.1). The singleton method works in L5+.
