### PR TITLE
add support for set custom calendar

### DIFF
--- a/DateIntlBuilder.php
+++ b/DateIntlBuilder.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Macroable;
 use IntlDateFormatter;
+use IntlCalendar;
 
 class DateIntlBuilder
 {
@@ -21,9 +22,11 @@ class DateIntlBuilder
         $this->langCode = $lang.'_'.strtoupper($lang);
     }
 
-    public function date($type, Carbon $carbon)
+    public function date($type, Carbon $carbon, $calendar = null)
     {
-        $fmt = new IntlDateFormatter($this->langCode, $this->getType($type), IntlDateFormatter::NONE, $carbon->tz);
+        $calendar = $this->getCalendar($carbon, $calendar);
+
+        $fmt = new IntlDateFormatter($this->langCode, $this->getType($type), IntlDateFormatter::NONE, $carbon->tz, $calendar);
 
         return $fmt->format($carbon->getTimestamp());
     }
@@ -46,9 +49,19 @@ class DateIntlBuilder
         throw new \Exception($type.' ... TYPE not found');
     }
 
-    public function time(Carbon $carbon, $withSeconds = false)
+    private function getCalendar(Carbon $carbon, String $calendar)
     {
-        $fmt = new IntlDateFormatter($this->langCode, IntlDateFormatter::NONE, $this->getTimeType($withSeconds), $carbon->tz);
+        return IntlCalendar::createInstance(
+            $carbon->tz,
+            $this->langCode . "@calendar=" . $calendar
+        );
+    }
+
+    public function time(Carbon $carbon, $withSeconds = false, $calendar = null)
+    {
+        $calendar = $this->getCalendar($carbon, $calendar);
+
+        $fmt = new IntlDateFormatter($this->langCode, IntlDateFormatter::NONE, $this->getTimeType($withSeconds), $carbon->tz, $calendar);
 
         return $fmt->format($carbon->getTimestamp());
     }
@@ -62,17 +75,22 @@ class DateIntlBuilder
         return IntlDateFormatter::SHORT;
     }
 
-    public function full($type, Carbon $carbon, $withSeconds = false)
+    public function full($type, Carbon $carbon, $withSeconds = false, $calendar = null)
     {
         $type = $this->getType($type);
-        $fmt = new IntlDateFormatter($this->langCode, $type, $this->getTimeType($withSeconds), $carbon->tz);
+
+        $calendar = $this->getCalendar($carbon, $calendar);
+
+        $fmt = new IntlDateFormatter($this->langCode, $type, $this->getTimeType($withSeconds), $carbon->tz, $calendar);
 
         return $fmt->format($carbon->getTimestamp());
     }
 
-    public function fullmix($dateType, $timeType, Carbon $carbon)
+    public function fullmix($dateType, $timeType, Carbon $carbon, $calendar = null)
     {
-        $fmt = new IntlDateFormatter($this->langCode, $this->getType($dateType), $this->getType($timeType), $carbon->tz);
+        $calendar = $this->getCalendar($carbon, $calendar);
+
+        $fmt = new IntlDateFormatter($this->langCode, $this->getType($dateType), $this->getType($timeType), $carbon->tz, $calendar);
 
         return $fmt->format($carbon->getTimestamp());
     }

--- a/DateIntlBuilder.php
+++ b/DateIntlBuilder.php
@@ -5,8 +5,8 @@ namespace Approached\LaravelDateInternational;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Traits\Macroable;
-use IntlDateFormatter;
 use IntlCalendar;
+use IntlDateFormatter;
 
 class DateIntlBuilder
 {
@@ -53,7 +53,7 @@ class DateIntlBuilder
     {
         return IntlCalendar::createInstance(
             $carbon->tz,
-            $this->langCode . "@calendar=" . $calendar
+            $this->langCode.'@calendar='.$calendar
         );
     }
 

--- a/helpers.php
+++ b/helpers.php
@@ -10,9 +10,9 @@ if (!function_exists('dateintl_date')) {
      *
      * @return string
      */
-    function dateintl_date($type, $dateObject)
+    function dateintl_date($type, $dateObject, $calendar = null)
     {
-        return app('dateintl')->date($type, $dateObject);
+        return app('dateintl')->date($type, $dateObject, $calendar);
     }
 }
 
@@ -26,9 +26,9 @@ if (!function_exists('dateintl_time')) {
      *
      * @return string
      */
-    function dateintl_time($dateObject, $withSeconds = false)
+    function dateintl_time($dateObject, $withSeconds = false, $calendar = null)
     {
-        return app('dateintl')->time($dateObject, $withSeconds);
+        return app('dateintl')->time($dateObject, $withSeconds, $calendar);
     }
 }
 
@@ -42,9 +42,9 @@ if (!function_exists('dateintl_full')) {
      *
      * @return string
      */
-    function dateintl_full($type, $dateObject, $withSeconds = false)
+    function dateintl_full($type, $dateObject, $withSeconds = false, $calendar = null)
     {
-        return app('dateintl')->full($type, $dateObject, $withSeconds);
+        return app('dateintl')->full($type, $dateObject, $withSeconds, $calendar);
     }
 }
 
@@ -58,8 +58,8 @@ if (!function_exists('dateintl_fullmix')) {
      *
      * @return string
      */
-    function dateintl_fullmix($type, $dateObject)
+    function dateintl_fullmix($type, $dateObject, $calendar = null)
     {
-        return app('dateintl')->dateintl_fullmix($type, $dateObject);
+        return app('dateintl')->dateintl_fullmix($type, $dateObject, $calendar = null);
     }
 }


### PR DESCRIPTION
I added Support for using Custom Calender with [`IntlCalendar`](http://php.net/manual/en/intldateformatter.setcalendar.php) :  
Usage for helpers (blade) example  :  
`dateintl_date('short', $date, 'calendar')`  
`calendar` could be these values :  
- persian
- japanese
- buddhist
- chinese
- indian
- islamic
- hebrew
- coptic 
- ethiopic

Usage with PHP :  
`$str = Dateintl::full('short', $date, 'calendar');`
### Note:   setting calendar is optional & fully backward compatible with old version
