### PR TITLE
added ability to set custom format/pattern 

### DIFF
--- a/src/DateIntlBuilder.php
+++ b/src/DateIntlBuilder.php
@@ -98,4 +98,22 @@ class DateIntlBuilder
 
         return $fmt->format($carbon->getTimestamp());
     }
+
+    public function pattern($pattern, Carbon $carbon, $calendar = null)
+    {
+      $type = $this->getType('full');
+
+      $calendar = $this->getCalendar($carbon, $calendar);
+
+      $fmt = new IntlDateFormatter($this->langCode, $type, $this->getTimeType(false), $carbon->tz, $calendar);
+
+      $fmt->setPattern($pattern);
+
+      return $fmt->format($carbon->getTimestamp());
+    }
+
+    public function format($pattern, Carbon $carbon, $calendar = null)
+    {
+      return $this->pattern($pattern, $carbon, $calendar);
+    }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -63,3 +63,19 @@ if (! function_exists('dateintl_fullmix')) {
         return app('dateintl')->dateintl_fullmix($type, $dateObject, $calendar = null);
     }
 }
+
+if (! function_exists('dateintl_format')) {
+
+    /**
+     * Generate a international date string.
+     *
+     * @param $format
+     * @param $dateObject
+     *
+     * @return string
+     */
+    function dateintl_format($format, $dateObject, $calendar = null)
+    {
+        return app('dateintl')->dateintl_format($format, $dateObject, $calendar = null);
+    }
+}


### PR DESCRIPTION
I have added one method (& one alias for that) to able using custom date time  pattern/format.
Usage of this method is very simple. just to following [this](http://userguide.icu-project.org/formatparse/datetime) document for custom format string.  

``` php
Dateintl::format('yyyymmdd hh:mm:ss z', $date);
```

Also can use `pattern` method instead :

``` php
Dateintl::pattern('yyyymmdd hh:mm:ss z', $date);
```

A new helper function is implemented called as `dateintl_format` with usage of :  

``` php
dateintl_format('yyyymmdd hh:mm:ss z', $date)
```
